### PR TITLE
Initial Python implementation of SSP2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install ssp-topopt
 The Python import package is `ssp_topopt`:
 
 ```python
-from ssp_topopt import conic_filter, get_conic_radius_from_eta_e, ssp1_bilinear
+from ssp_topopt import conic_filter, get_conic_radius_from_eta_e, ssp1_bilinear,ssp2
 ```
 
 For local development:

--- a/examples/python/ssp2_example.py
+++ b/examples/python/ssp2_example.py
@@ -1,0 +1,173 @@
+"""
+This is a simple example that demonstrates how to use the "SSP2" algorithm
+for subpixel-smoothed projection, combined with bilinear interpolation and conic smoothing.
+We set up a simplistic gradient-based optimization problem that attempts
+to drive the mean of the output to zero. We set β=∞ and show the gradient is nonzero.
+"""
+
+import time
+
+import nlopt
+import numpy as np
+from jax import grad, jit, value_and_grad,vmap
+from jax import numpy as jnp
+from matplotlib import pyplot as plt
+from ssp_topopt import conic_filter, get_conic_radius_from_eta_e,ssp2
+from ssp_topopt import utils
+import jax
+
+
+def figure_of_merit(x: jnp.ndarray) -> float:
+    """A simple, convex reduction mean as the FOM.
+
+    FOM = 1/(n*m)ΣΣ|x|^2
+    """
+    return jnp.mean((jnp.abs(x) ** 2).flatten())
+
+
+def full_system(x: jnp.ndarray, beta, eta_i, resolution) -> float:
+    """Include the projection and FOM"""
+    return figure_of_merit(ssp2(x, beta, eta_i, resolution))
+
+
+def main():
+    """Run the example and optimization."""
+    
+    # --------------------------------------------- #
+    # Visualize the SSP2 transformation
+    # --------------------------------------------- #
+
+    # First set up a random initial condition. We'll use dimensionless units for everything.
+    lx = 2.0
+    ly = 2.0
+    resolution = 50
+    beta = np.inf
+    eta_i = 0.5
+    eta_e = 0.75
+    lengthscale = 0.1
+    filter_radius = get_conic_radius_from_eta_e(lengthscale, eta_e)
+    nx = int(np.round(lx * resolution) + 1)
+    ny = int(np.round(ly * resolution) + 1)
+
+    np.random.seed(42)
+    rho = np.random.rand(nx, ny)
+
+    rho_filtered = conic_filter(rho, filter_radius, lx, ly, resolution)
+
+    rho_projected = ssp2(rho_filtered, beta, eta_i, resolution)
+
+
+
+    plt.figure(figsize=(6, 3))
+    plt.subplot(1, 2, 1)
+    plt.imshow(rho_filtered, vmin=0, vmax=1, cmap="binary")
+    plt.title("Input")
+    plt.colorbar()
+    plt.subplot(1, 2, 2)
+    plt.imshow(rho_projected, vmin=0, vmax=1, cmap="binary")
+    plt.colorbar()
+    plt.title("SSP2 Output")
+    plt.tight_layout()
+    plt.savefig("projection.png")
+
+
+    # --------------------------------------------- #
+    # Visualize the SSP2 gradient for β=∞
+    # --------------------------------------------- #
+
+    d_fom = grad(full_system)
+    df_drho = d_fom(rho_filtered, beta, eta_i, resolution)
+    max_val = jnp.max(df_drho)
+    min_val = jnp.min(df_drho)
+    vmax_vmin = max([abs(max_val), abs(min_val)])
+
+    plt.figure(figsize=(6, 3))
+    plt.subplot(1, 2, 1)
+    plt.imshow(rho_projected, vmin=0, vmax=1, cmap="binary")
+    plt.title("SSP2 Output")
+    plt.colorbar()
+    plt.subplot(1, 2, 2)
+    plt.imshow(df_drho, vmin=-vmax_vmin, vmax=vmax_vmin, cmap="RdBu")
+    plt.colorbar()
+    plt.title("Gradient")
+    plt.tight_layout()
+    plt.savefig("gradient.png")
+
+
+    # --------------------------------------------- #
+    # Shape optimization via nlopt
+    # --------------------------------------------- #
+
+    def optimization_objective(rho_flat: jnp.ndarray) -> jnp.ndarray:
+        rho_design = rho_flat.reshape((nx, ny))
+        rho_design_filtered = conic_filter(rho_design, filter_radius, lx, ly, resolution)
+        rho_design_projected = ssp2(
+            rho_design_filtered, beta, eta_i, resolution
+        )
+        return figure_of_merit(rho_design_projected)
+
+    objective_and_grad = jit(value_and_grad(optimization_objective))
+
+    iteration_history = []
+    time_history = []
+    fom_history = []
+    start_time = time.perf_counter()
+
+    def nlopt_objective(x: np.ndarray, grad_out: np.ndarray) -> float:
+        fom_value, gradient = objective_and_grad(jnp.asarray(x))
+
+        if grad_out.size > 0:
+            grad_out[:] = np.asarray(gradient, dtype=float)
+
+        iteration = len(fom_history) + 1
+        elapsed = time.perf_counter() - start_time
+        fom_scalar = float(fom_value)
+
+        iteration_history.append(iteration)
+        time_history.append(elapsed)
+        fom_history.append(fom_scalar)
+
+        print(f"iter={iteration:03d} time={elapsed:8.3f}s FOM={fom_scalar:.6e}")
+        return fom_scalar
+
+    opt = nlopt.opt(nlopt.LD_CCSAQ, nx * ny)
+    opt.set_lower_bounds(np.zeros(nx * ny))
+    opt.set_upper_bounds(np.ones(nx * ny))
+    opt.set_min_objective(nlopt_objective)
+    opt.set_maxeval(25)
+
+    x_opt = opt.optimize(rho.ravel())
+    final_fom = opt.last_optimum_value()
+
+    rho_opt = x_opt.reshape((nx, ny))
+    rho_opt_filtered = conic_filter(rho_opt, filter_radius, lx, ly, resolution)
+    rho_opt_projected = np.asarray(
+        ssp2(rho_opt_filtered, beta, eta_i, resolution)
+    )
+
+    print("\nOptimization complete")
+    print(f"status={opt.last_optimize_result()} final_fom={final_fom:.6e}")
+
+    print("\nIteration log (time in seconds):")
+    for iteration, elapsed, fom in zip(iteration_history, time_history, fom_history):
+        print(f"iter={iteration:03d} time={elapsed:8.3f}s FOM={fom:.6e}")
+
+    plt.figure(figsize=(6, 3))
+    plt.subplot(1, 2, 1)
+    plt.semilogy(iteration_history, fom_history, marker="o", linewidth=1.5)
+    plt.xlabel("Iteration")
+    plt.ylabel("FOM")
+    plt.title("FOM vs Iteration")
+
+    plt.subplot(1, 2, 2)
+    im = plt.imshow(rho_opt_projected, vmin=0, vmax=1, cmap="binary")
+    plt.title("Final SSP Projected Design")
+    plt.colorbar(im)
+
+    plt.tight_layout()
+    plt.savefig("optimization.png")
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
 ]
 dependencies = [
   "numpy>=1.24",
-  jax>=0.4,<=0.7.2,
-  "interpax==0.3.13",
+  "jax>=0.4,<=0.7.2",
+  "interpax>=0.3.13",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "numpy>=1.24",
-  "jax==0.7.2",
+  jax>=0.4,<=0.7.2,
   "interpax==0.3.13",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ classifiers = [
 ]
 dependencies = [
   "numpy>=1.24",
-  "jax>=0.4",
+  "jax==0.7.2",
+  "interpax==0.3.13",
 ]
 
 [project.urls]

--- a/src/python/ssp_topopt/__init__.py
+++ b/src/python/ssp_topopt/__init__.py
@@ -1,10 +1,11 @@
 """Public Python API for smoothed subpixel projection (SSP) for topology optimization."""
 
-from .core import ssp1_bilinear
+from .core import ssp1_bilinear,ssp2
 from .utils import conic_filter, get_conic_radius_from_eta_e, tanh_projection
 
 __all__ = [
     "ssp1_bilinear",
+    "ssp2",
     "conic_filter",
     "get_conic_radius_from_eta_e",
     "tanh_projection",

--- a/src/python/ssp_topopt/core.py
+++ b/src/python/ssp_topopt/core.py
@@ -4,7 +4,7 @@ These are the core algorithms and routines behind SSP.
 
 from jax import numpy as jnp
 
-from .utils import ArrayLikeType, tanh_projection
+from .utils import ArrayLikeType, tanh_projection, gradient,hessian
 
 # Naively we might pick a smoothing radius of exactly 0.5 (such that the diameter 
 # of the smoothing kernel spans the full pixel/voxel). However, in the case when 
@@ -65,25 +65,24 @@ def ssp1_bilinear(
         The projected and smoothed output.
 
     Example:
-        >>> Lx = 2; Ly = 2
+        >>> lx = 2.0
+        >>> ly = 2.0
         >>> resolution = 50
-        >>> eta_i = 0.5; eta_e = 0.75
+        >>> beta = np.inf
+        >>> eta_i = 0.5
+        >>> eta_e = 0.75
         >>> lengthscale = 0.1
         >>> filter_radius = get_conic_radius_from_eta_e(lengthscale, eta_e)
-        >>> Nx = onp.round(Lx * resolution) + 1
-        >>> Ny = onp.round(Ly * resolution) + 1
-        >>> rho = onp.random.rand(Nx, Ny)
-        >>> beta = npa.inf
-        >>> rho_filtered = conic_filter(rho, filter_radius, Lx, Ly, resolution)
-        >>> rho_projected = smoothed_projection(rho_filtered, beta, eta_i, resolution)
+        >>> nx = int(np.round(lx * resolution) + 1)
+        >>> ny = int(np.round(ly * resolution) + 1)
+        >>> np.random.seed(42)
+        >>> rho = np.random.rand(nx, ny)
+        >>> rho_filtered = conic_filter(rho, filter_radius, lx, ly, resolution)
+        >>> rho_projected = ssp1_bilinear(rho_filtered, beta, eta_i, resolution)
     """
-    # TODO [alechammond] The current implementation is ported from meep 
-    # and only supports 2D inputs. We'll want to generalize this to 
-    # arbitrary dimensions.
-
     # TODO [alechammond] Note that currently, the underlying assumption 
     # is that the smoothing kernel is a circle, which means dx = dy.
-    dx = dy = 1 / resolution
+    dx = 1 / resolution
     R_smoothing = smoothing_radius * dx
 
     rho_projected = tanh_projection(rho_filtered, beta=beta, eta=eta)
@@ -93,9 +92,13 @@ def ssp1_bilinear(
     # gradient essentially represents the normal direction pointing the the
     # nearest inteface.
     rho_filtered_grad = jnp.gradient(rho_filtered)
-    rho_filtered_grad_helper = (rho_filtered_grad[0] / dx) ** 2 + (
-        rho_filtered_grad[1] / dy
-    ) ** 2
+    if not isinstance(rho_filtered_grad, (tuple, list)):
+        rho_filtered_grad = (rho_filtered_grad,)
+
+    inv_dx = resolution
+    rho_filtered_grad_helper = (rho_filtered_grad[0] * inv_dx) ** 2
+    for grad_axis in rho_filtered_grad[1:]:
+        rho_filtered_grad_helper = rho_filtered_grad_helper + (grad_axis * inv_dx) ** 2
 
     # Note that a uniform field (norm=0) is problematic, because it creates
     # divide by zero issues and makes backpropagation difficult, so we sanitize
@@ -138,6 +141,164 @@ def ssp1_bilinear(
     rho_filtered_minus = rho_filtered - R_smoothing * rho_filtered_grad_norm_eff * F
     rho_filtered_plus = (
         rho_filtered + R_smoothing * rho_filtered_grad_norm_eff * F_minus
+    )
+
+    # Finally, we project the extents of our range.
+    rho_minus_eff_projected = tanh_projection(rho_filtered_minus, beta=beta, eta=eta)
+    rho_plus_eff_projected = tanh_projection(rho_filtered_plus, beta=beta, eta=eta)
+
+    # Only apply smoothing to interfaces
+    rho_projected_smoothed = (
+        1 - F
+    ) * rho_minus_eff_projected + F * rho_plus_eff_projected
+    return jnp.where(
+        needs_smoothing,
+        rho_projected_smoothed,
+        rho_projected,
+    )
+
+
+
+
+def ssp2(
+    rho_filtered: ArrayLikeType,
+    beta: float,
+    eta: float,
+    resolution: float,
+    smoothing_radius: float = DEFAULT_SMOOTHING_RADIUS
+):
+    """Project using the original SSP2 algorithm with bicubic interpolation.
+
+    This technique integrates out the discontinuity within the projection
+    function, allowing the user to smoothly increase β from 0 to ∞ without
+    losing the gradient. Effectively, a level set is created, and from this
+    level set, SSP2 bicubic subpixel smoothing is applied to the interfaces (if
+    any are present).
+
+    In order for this to work, the input array must already be smooth (e.g. by
+    filtering).
+
+    While the original approach involves numerical quadrature, this approach
+    performs a "trick" by assuming that the user is always infinitely projecting
+    (β=∞). In this case, the expensive quadrature simplifies to an analytic
+    fill-factor expression. When to use this fill factor requires some careful
+    logic.
+
+    For one, we want to make sure that the user can indeed project at any level
+    (not just infinity). So in these cases, we simply check if in interface is
+    within the pixel. If not, we revert to the standard filter plus project
+    technique.
+
+    If there is an interface, we want to make sure the derivative remains
+    continuous both as the interface leaves the cell, *and* as it crosses the
+    center. To ensure this, we need to account for the different possibilities.
+
+    Refs:
+
+    G. Romano, R. Arrieta, and S. G. Johnson, 
+    “Differentiating through binarized topology changes: Second-order 
+    subpixel-smoothed projection,” arXiv.org e-Print archive, 2601.10737, 
+    January 2026.
+    
+    A. M. Hammond, A. Oskooi, I. M. Hammond, M. Chen, S. E. Ralph, and 
+    S. G. Johnson, “Unifying and accelerating level-set and density-based topology 
+    optimization by subpixel-smoothed projection,” Optics Express, vol. 33, 
+    pp. 33620-33642, July 2025. Editor's Pick.
+
+    Args:
+        rho_filtered: The (2D) input design parameters (already filered e.g.
+            with a conic filter).
+        beta: The thresholding parameter in the range [0, inf]. Determines the
+            degree of binarization of the output.
+        eta: The threshold point in the range [0, 1].
+        resolution: resolution of the design grid.
+        smoothing_radius: The smoothing radius of the kernel relative to the 
+            pixel/voxel "width."
+       
+    Returns:
+        The projected and smoothed output.
+
+    Example:
+        >>> lx = 2.0
+        >>> ly = 2.0
+        >>> resolution = 50
+        >>> beta = np.inf
+        >>> eta_i = 0.5
+        >>> eta_e = 0.75
+        >>> lengthscale = 0.1
+        >>> filter_radius = get_conic_radius_from_eta_e(lengthscale, eta_e)
+        >>> nx = int(np.round(lx * resolution) + 1)
+        >>> ny = int(np.round(ly * resolution) + 1)
+        >>> np.random.seed(42)
+        >>> rho = np.random.rand(nx, ny)
+        >>> rho_filtered = conic_filter(rho, filter_radius, lx, ly, resolution)
+        >>> rho_projected = ssp2(rho_filtered, beta, eta_i, resolution)
+    """
+    # TODO [alechammond] Note that currently, the underlying assumption 
+    # is that the smoothing kernel is a circle, which means dx = dy.
+    dx = 1 / resolution
+    R_smoothing = smoothing_radius * dx
+
+    rho_projected = tanh_projection(rho_filtered, beta=beta, eta=eta)
+
+    # Compute the spatial gradient (using finite differences) of the *filtered*
+    # field, which will always be smooth and is the key to our approach. This
+    # gradient essentially represents the normal direction pointing the the
+    # nearest inteface.
+
+    
+   
+    #SSP1
+    rho_filtered_grad  = gradient(rho_filtered,resolution)
+    den_helper = jnp.sum(rho_filtered_grad**2,axis=-1) 
+
+    
+    #SSP2 correction 
+    rho_filtered_hessian = hessian(rho_filtered,resolution)
+    den_helper  += jnp.sum(rho_filtered_hessian**2, axis=(-2,-1))*R_smoothing**2
+
+
+    # Note that a uniform field (norm=0) is problematic, because it creates
+    # divide by zero issues and makes backpropagation difficult, so we sanitize
+    # and determine where smoothing is actually needed. The value where we don't
+    # need smoothings doesn't actually matter, since all our computations our
+    # purely element-wise (no spatial locality) and those pixels will instead
+    # rely on the standard projection. So just use 1, since it's well behaved.
+    nonzero_norm = jnp.abs(den_helper) > 0
+
+    den_norm = jnp.sqrt(
+        jnp.where(nonzero_norm, den_helper, 1)
+    )
+    den_eff = jnp.where(nonzero_norm, den_norm, 1)
+
+    # The distance for the center of the pixel to the nearest interface
+    d = (eta - rho_filtered) / den_eff
+
+    # Only need smoothing if an interface lies within the voxel. Since d is
+    # actually an "effective" d by this point, we need to ignore values that may
+    # have been sanitized earlier on.
+    needs_smoothing = nonzero_norm & (jnp.abs(d) < R_smoothing)
+
+    # The fill factor is used to perform the SSP2 subpixel smoothing.
+    # We use the (2D) analytic expression that comes when assuming the smoothing
+    # kernel is a circle. Note that because the kernel contains some
+    # expressions that are sensitive to NaNs, we have to use the "double where"
+    # trick to avoid the Nans in the backward trace. This is a common problem
+    # with array-based AD tracers, apparently. See here:
+    # https://github.com/google/jax/issues/1052#issuecomment-5140833520
+    d_R = d / R_smoothing
+    F = jnp.where(
+        needs_smoothing, 0.5 - 15 / 16 * d_R + 5 / 8 * d_R**3 - 3 / 16 * d_R**5, 1.0
+    )
+    # F(-d)
+    F_minus = jnp.where(
+        needs_smoothing, 0.5 + 15 / 16 * d_R - 5 / 8 * d_R**3 + 3 / 16 * d_R**5, 1.0
+    )
+
+    # Determine the upper and lower bounds of materials in the current pixel (before projection).
+    rho_filtered_minus = rho_filtered - R_smoothing * den_eff * F
+    rho_filtered_plus = (
+        rho_filtered + R_smoothing * den_eff * F_minus
     )
 
     # Finally, we project the extents of our range.

--- a/src/python/ssp_topopt/utils.py
+++ b/src/python/ssp_topopt/utils.py
@@ -317,7 +317,7 @@ def gradient(x:             np.ndarray,
 
       Args:
           x: 2d input array sampled on the design grid.
-          resolution: design-grid resolution, allowing isotropic or anisotropic input.
+          resolution: design-grid resolution.
           method: interpolation method. See
               https://interpax.readthedocs.io/en/latest/_api/interpax.interp2d.html#interpax.interp2d
               for the available methods.
@@ -351,7 +351,7 @@ def hessian(x:             np.ndarray,
 
       Args:
           x: 2d input array sampled on the design grid.
-          resolution: design-grid resolution, allowing isotropic or anisotropic input.
+          resolution: design-grid resolution.
           method: interpolation method. See
               https://interpax.readthedocs.io/en/latest/_api/interpax.interp2d.html#interpax.interp2d
               for the available methods.

--- a/src/python/ssp_topopt/utils.py
+++ b/src/python/ssp_topopt/utils.py
@@ -313,6 +313,18 @@ def gradient(x:             np.ndarray,
              resolution:    float,
              method:        str = 'cubic2'
              ):
+      """Compute the spatial gradient of a 2D field via differentiable interpolation.
+
+      Args:
+          x: 2d input array sampled on the design grid.
+          resolution: design-grid resolution, allowing isotropic or anisotropic input.
+          method: interpolation method. See
+              https://interpax.readthedocs.io/en/latest/_api/interpax.interp2d.html#interpax.interp2d
+              for the available methods.
+
+      Returns:
+          A `(Nx, Ny, 2)` array containing the x- and y-derivatives at each grid point.
+      """
 
       resolution = _get_resolution(resolution)
       dx         = 1/resolution[0]
@@ -335,6 +347,18 @@ def hessian(x:             np.ndarray,
              resolution:    float,
              method:        str = 'cubic2'
              ):
+      """Compute the spatial Hessian of a 2D field via differentiable interpolation.
+
+      Args:
+          x: 2d input array sampled on the design grid.
+          resolution: design-grid resolution, allowing isotropic or anisotropic input.
+          method: interpolation method. See
+              https://interpax.readthedocs.io/en/latest/_api/interpax.interp2d.html#interpax.interp2d
+              for the available methods.
+
+      Returns:
+          A `(Nx, Ny, 2, 2)` array containing the second derivatives at each grid point.
+      """
 
       resolution = _get_resolution(resolution)
       dx         = 1/resolution[0]

--- a/src/python/ssp_topopt/utils.py
+++ b/src/python/ssp_topopt/utils.py
@@ -10,9 +10,13 @@ to generalize to arbitrary dimensions.
 
 from typing import Union, List, Tuple
 import numpy as np
+from interpax import interp2d
+
 
 # Use jax as our autograd engine
 from jax import numpy as jnp
+from jax import vmap,grad
+import jax
 
 ArrayLikeType = Union[List, Tuple, np.ndarray]
 
@@ -305,6 +309,53 @@ def conic_filter(
     return convolve_design_weights_and_kernel(x, h, periodic_axes)
 
 
+def gradient(x:             np.ndarray,
+             resolution:    float,
+             method:        str = 'cubic2'
+             ):
+
+      resolution = _get_resolution(resolution)
+      dx         = 1/resolution[0]
+      dy         = 1/resolution[1]
+      Nx,Ny      = x.shape
+      Lx         = dx*(Nx-1)
+      Ly         = dy*(Ny-1)
+      x_coords   = jnp.linspace(-Lx/2, Lx/2, Nx, endpoint = True)
+      y_coords   = jnp.linspace(-Ly/2, Ly/2, Ny, endpoint = True)
+   
+      interpolator = lambda p: interp2d(*p,x_coords,y_coords, x,method=method)
+
+      Xf, Yf = jnp.meshgrid(x_coords, y_coords, indexing="ij")
+      points = jnp.stack((Xf.ravel(),Yf.ravel()), axis=-1)
+
+      return vmap(grad(interpolator))(points).reshape((Nx,Ny,2))
+
+
+def hessian(x:             np.ndarray,
+             resolution:    float,
+             method:        str = 'cubic2'
+             ):
+
+      resolution = _get_resolution(resolution)
+      dx         = 1/resolution[0]
+      dy         = 1/resolution[1]
+      Nx,Ny      = x.shape
+      Lx         = dx*(Nx-1)
+      Ly         = dy*(Ny-1)
+      x_coords   = jnp.linspace(-Lx/2, Lx/2, Nx, endpoint = True)
+      y_coords   = jnp.linspace(-Ly/2, Ly/2, Ny, endpoint = True)
+   
+      interpolator = lambda p: interp2d(*p,x_coords,y_coords, x,method=method)
+
+      Xf, Yf = jnp.meshgrid(x_coords, y_coords, indexing="ij")
+      points = jnp.stack((Xf.ravel(),Yf.ravel()), axis=-1)
+
+      return vmap(jax.hessian(interpolator))(points).reshape((Nx,Ny,2,2))
+
+
+
+
+
 def tanh_projection(x: np.ndarray, beta: float, eta: float) -> np.ndarray:
     """Sigmoid projection filter.
 
@@ -321,6 +372,11 @@ def tanh_projection(x: np.ndarray, beta: float, eta: float) -> np.ndarray:
     Returns:
         The filtered design weights.
     """
+
+    if beta == 0:
+        # No projection
+        return x
+
     if beta == jnp.inf:
         # Note that backpropagating through here can produce NaNs. So we
         # manually specify the step function to keep the gradient clean.

--- a/tests/python/test_ssp2.py
+++ b/tests/python/test_ssp2.py
@@ -1,0 +1,109 @@
+import unittest
+
+import nlopt
+import numpy as np
+from jax import grad, value_and_grad
+from jax import numpy as jnp
+
+from ssp_topopt import conic_filter, get_conic_radius_from_eta_e, ssp2
+
+
+def figure_of_merit(x: jnp.ndarray) -> float:
+    """Simple convex objective used in the example."""
+    return jnp.mean((jnp.abs(x) ** 2).flatten())
+
+
+def full_system(x: jnp.ndarray, beta: float, eta_i: float, resolution: int) -> float:
+    """Projection followed by scalar objective."""
+    return figure_of_merit(ssp2(x, beta, eta_i, resolution))
+
+
+class TestSSPTopopt1Bilinear(unittest.TestCase):
+    def setUp(self):
+        self.lx = 2.0
+        self.ly = 2.0
+        self.resolution = 50
+        self.eta_i = 0.5
+        self.eta_e = 0.75
+        self.lengthscale = 0.25
+        self.beta = np.inf
+        self.filter_radius = get_conic_radius_from_eta_e(self.lengthscale, self.eta_e)
+        self.nx = int(np.round(self.lx * self.resolution) + 1)
+        self.ny = int(np.round(self.ly * self.resolution) + 1)
+        self.seed = 42
+
+    def _random_design(self) -> np.ndarray:
+        np.random.seed(self.seed)
+        return np.random.rand(self.nx, self.ny)
+
+    def _filter_and_project(self, rho_design: np.ndarray):
+        rho_filtered = conic_filter(
+            rho_design,
+            self.filter_radius,
+            self.lx,
+            self.ly,
+            self.resolution,
+        )
+        rho_projected = ssp2(
+            rho_filtered,
+            self.beta,
+            self.eta_i,
+            self.resolution,
+        )
+        return rho_filtered, rho_projected
+
+    def test_smoke_pipeline(self):
+        """Smoke test: import package and run tiny filter + projection pipeline."""
+        rho = self._random_design()
+        _, rho_projected = self._filter_and_project(rho)
+
+        rho_projected_np = np.asarray(rho_projected)
+
+        self.assertEqual(rho_projected_np.shape, rho.shape)
+        self.assertTrue(np.isfinite(rho_projected_np).all())
+        self.assertGreaterEqual(rho_projected_np.min(), -1e-7)
+        self.assertLessEqual(rho_projected_np.max(), 1.0 + 1e-7)
+
+    def test_nonzero_gradient_at_infinite_beta(self):
+        """For beta=inf, verify gradient is nonzero as in the example."""
+        rho = self._random_design()
+        rho_filtered, _ = self._filter_and_project(rho)
+
+        d_fom = grad(full_system)
+        df_drho = d_fom(rho_filtered, self.beta, self.eta_i, self.resolution)
+        grad_norm = float(np.linalg.norm(np.asarray(df_drho).ravel(), ord=2))
+
+        self.assertGreater(grad_norm, 0.0)
+
+    def test_ccsa_optimization_reduces_fom_to_tolerance(self):
+        """Run a mini CCSA optimization and verify FOM reaches target tolerance."""
+        rho0 = self._random_design()
+
+        def optimization_objective(rho_flat: jnp.ndarray) -> jnp.ndarray:
+            rho_design = rho_flat.reshape((self.nx, self.ny))
+            _, rho_projected = self._filter_and_project(rho_design)
+            return figure_of_merit(rho_projected)
+
+        objective_and_grad = value_and_grad(optimization_objective)
+
+        def nlopt_objective(x: np.ndarray, grad_out: np.ndarray) -> float:
+            fom_value, gradient = objective_and_grad(jnp.asarray(x))
+            if grad_out.size > 0:
+                grad_out[:] = np.asarray(gradient, dtype=float)
+            return float(fom_value)
+
+        opt = nlopt.opt(nlopt.LD_CCSAQ, self.nx * self.ny)
+        opt.set_lower_bounds(np.zeros(self.nx * self.ny))
+        opt.set_upper_bounds(np.ones(self.nx * self.ny))
+        opt.set_min_objective(nlopt_objective)
+        opt.set_maxeval(15)
+
+        x_opt = opt.optimize(rho0.ravel())
+        final_fom = float(opt.last_optimum_value())
+
+        self.assertEqual(x_opt.size, self.nx * self.ny)
+        self.assertLessEqual(final_fom, 1e-10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

This PR introduces an initial Python implementation of SSP2.

## Known limitations

- **Periodic boundary conditions:** Not yet supported. Further discussion is needed regarding endpoint handling.
- **JAX pinned to `0.7.2`:** Newer versions throw the following error when combining FFT-based filtering with `interpax` interpolation:
```
  RET_CHECK failure (external/xla/xla/backends/cpu/runtime/fft_thunk.cc:167)
```
Example and test: Currently copied from the SSP1 counterparts with just the projection method switched.